### PR TITLE
feat(best-pratices): disable class methods use this

### DIFF
--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -12,9 +12,7 @@ module.exports = {
         "block-scoped-var": "error",
 
         // enforce that class methods utilize "this"
-        "class-methods-use-this": ["error", {
-            exceptMethods: []
-        }],
+        "class-methods-use-this": "off",
 
         // enforce a maximum cyclomatic complexity allowed in a program
         complexity: "off",


### PR DESCRIPTION
Signed-off-by: Jimmy Fortin <jimmy.fortin@corp.ovh.com>

There is a simple explanation of why I think we should disable this rule:

Since we are using babel (es6) and we are using classes, functions not always using this but are still related and specific to a class. Also, because we are not using any import file system (like requirejs or webpack) we can't write function at the root of the file otherwise those functions will be defined on the global scope and we could have conflit.

There is an example of code if we keep this rule activated:

```javascript
function addStringPrefix(text, prefix) {
    return prefix + text;
}

export class Test {
    constructor(test, test2) {
        this.test = test;
        this.test2 = test2;
    }

    foo() {
        return addStringPrefix(this.test, "test1");
    }

    bar() {
        return addStringPrefix(this.test2, "test2");
    }
}
```

There is an example of code if we disable this rule:

```javascript
export class Test {
    constructor(test, test2) {
        this.test = test;
        this.test2 = test2;
    }

    _addStringPrefix(text, prefix) {
        return prefix + text;
    }

    foo() {
        return this._addStringPrefix(this.test, "test1");
    }

    bar() {
        return this._addStringPrefix(this.test2, "test2");
    }
}
```