### PR TITLE
fix(style): add indent rule for switch-case

### DIFF
--- a/rules/style.js
+++ b/rules/style.js
@@ -81,7 +81,8 @@ module.exports = {
             },
             CallExpression: {
                 arguments: "first"
-            }
+            },
+            SwitchCase: 1
         }],
 
         // enforce the consistent use of either double or single quotes in JSX attributes


### PR DESCRIPTION
Add a new rule to fix weird switch indentation.

Before:

```javascript
switch (foo) {
case "bar": return "bar";
case "baz": return "baz";
default: return "qux";
}
```

After:

```javascript
switch (foo) {
    case "bar": return "bar";
    case "baz": return "baz";
    default: return "qux";
}
```