### PR TITLE
fix(style): allow underscore dangle

### DIFF
--- a/rules/style.js
+++ b/rules/style.js
@@ -211,8 +211,8 @@ module.exports = {
         // disallow trailing whitespace at the end of lines
         "no-trailing-spaces": "error",
 
-        // disallow dangling underscores in identifiers
-        "no-underscore-dangle": ["error", { allowAfterThis: true, allowAfterSuper: true }],
+        // allow dangling underscores in identifiers
+        "no-underscore-dangle": ["off"],
 
         // disallow ternary operators when simpler alternatives exist
         "no-unneeded-ternary": ["error", { defaultAssignment: false }],


### PR DESCRIPTION
Allow underscore dangle everywhere.

Before, this was not allowed:

```javascript
function (foo) {
    const _foo = foo;
    if (/* a condition on _foo */) {
        _foo = "another_value";
    }
}
```

This rule can be annoying when "no-param-reassign" is also activated because it forces you to find another weird name for your variable:

```javascript
function (foo) {
    const newFoo = foo;
    if (/* a condition on newFoo */) {
        newFoo = "another_value";
    }
}
```