### PR TITLE
Disable class-methods-use-this: the return

### DIFF
--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -12,9 +12,7 @@ module.exports = {
         "block-scoped-var": "error",
 
         // enforce that class methods utilize "this"
-        "class-methods-use-this": ["error", {
-            exceptMethods: []
-        }],
+        "class-methods-use-this": ["off"],
 
         // enforce a maximum cyclomatic complexity allowed in a program
         complexity: "off",


### PR DESCRIPTION
Hi,

Today, I noticed that this rule forces to write `{{FooCtrl.constructor.aMethod()}}` in our templates.
I think that `constructor` has really nothing to do in template because it's like polluting the data model.

My suggestion is simply to remove this rule, keeping in mind that `class-methods-use-this` is a eslint rule that exists to avoid ... I think perf problems (https://jsperf.com/static-vs-prototype-methods-test) and maybe memory problems.

The question is: should we focus on performance versus code aesthetics, even if we're not sure that performance will be really better? (Can/should we test it?)

Arguments?

